### PR TITLE
Waveshare RP2350-USB-A board support

### DIFF
--- a/Firmware/RP2040/CMakeLists.txt
+++ b/Firmware/RP2040/CMakeLists.txt
@@ -146,6 +146,12 @@ elseif(OGXM_BOARD STREQUAL "PICO_ESP32")
         add_definitions(-DOGXM_ESP32_RETAIL)
     endif()
 
+elseif(OGXM_BOARD STREQUAL "RP2350_USB_A")
+    set(EN_USB_HOST TRUE)
+    set(PICO_PLATFORM rp2350)
+    set(EN_RGB TRUE)
+    set(FLASH_SIZE_MB 2)
+
 else()
     message(FATAL_ERROR "Invalid OGXM_BOARD value. See options in src/board_config.h")
 

--- a/Firmware/RP2040/src/OGXMini/OGXMini_Standard.cpp
+++ b/Firmware/RP2040/src/OGXMini/OGXMini_Standard.cpp
@@ -1,5 +1,5 @@
 #include "board_config.h"
-#if (OGXM_BOARD == ADA_FEATHER) || (OGXM_BOARD == RP_ZERO) || (OGXM_BOARD == PI_PICO) || (OGXM_BOARD == PI_PICO2)
+#if (OGXM_BOARD == ADA_FEATHER) || (OGXM_BOARD == RP_ZERO) || (OGXM_BOARD == PI_PICO) || (OGXM_BOARD == PI_PICO2) || (OGXM_BOARD == RP2350_USB_A)
 
 #include <pico/multicore.h>
 

--- a/Firmware/RP2040/src/board_config.h
+++ b/Firmware/RP2040/src/board_config.h
@@ -15,6 +15,7 @@
 #define INTERNAL_4CH 7
 #define EXTERNAL_4CH 8
 #define PICO_ESP32 9
+#define RP2350_USB_A 10
 
 #define SYSCLOCK_KHZ 240000
 
@@ -81,6 +82,10 @@
         #undef MAX_GAMEPADS
         #define MAX_GAMEPADS 1
     #endif
+
+#elif OGXM_BOARD == RP2350_USB_A
+    #define PIO_USB_DP_PIN    12
+    #define RGB_PXL_PIN       16
 
 #endif // OGXM_BOARD
 


### PR DESCRIPTION
Waveshare RP2350-USB-A board support
![GltzhVLXwAAsNZv](https://github.com/user-attachments/assets/eb4d977c-4461-498a-8318-f8c971cce0dd)
