### PR TITLE
RP2350_ZERO support

### DIFF
--- a/Firmware/RP2040/CMakeLists.txt
+++ b/Firmware/RP2040/CMakeLists.txt
@@ -167,6 +167,13 @@ elseif(OGXM_BOARD STREQUAL "ESP32_BLUERETRO_I2C")
         add_compile_definitions(OGXM_RETAIL=1)
     endif()
 
+elseif(OGXM_BOARD STREQUAL "RP2350_ZERO")
+    add_compile_definitions(CONFIG_OGXM_BOARD_RP2350_ZERO)
+    set(EN_USB_HOST TRUE)
+    set(PICO_PLATFORM rp2350)
+    set(EN_RGB TRUE)
+    set(FLASH_SIZE_MB 2)
+    
 else()
     message(FATAL_ERROR "Invalid OGXM_BOARD value. See options in src/board_config.h")
 

--- a/Firmware/RP2040/src/Board/Config.h
+++ b/Firmware/RP2040/src/Board/Config.h
@@ -9,7 +9,8 @@
 #define ESP32_BLUERETRO_I2C 5
 #define EXTERNAL_4CH_I2C    6
 #define INTERNAL_4CH_I2C    7
-#define BOARDS_COUNT        8
+#define RP2350_ZERO         8
+#define BOARDS_COUNT        9
 
 #define SYSCLOCK_KHZ 240000
 
@@ -83,6 +84,11 @@
     #define MODE_SEL_PIN        21
     #define ESP_PROG_PIN        20 // ESP32 IO0
     #define ESP_RST_PIN         8  // ESP32 EN
+
+    #elif defined(CONFIG_OGXM_BOARD_RP2350_ZERO)
+    #define OGXM_BOARD          RP2350_ZERO
+    #define PIO_USB_DP_PIN      10 // DM = 11
+    #define RGB_PXL_PIN         16
 
     #if MAX_GAMEPADS > 1
         #undef MAX_GAMEPADS

--- a/Firmware/RP2040/src/OGXMini/Board/Standard.cpp
+++ b/Firmware/RP2040/src/OGXMini/Board/Standard.cpp
@@ -1,6 +1,6 @@
 #include "Board/Config.h"
 #include "OGXMini/Board/Standard.h"
-#if ((OGXM_BOARD == PI_PICO) || (OGXM_BOARD == RP2040_ZERO) || (OGXM_BOARD == ADAFRUIT_FEATHER))
+#if ((OGXM_BOARD == PI_PICO) || (OGXM_BOARD == RP2040_ZERO) || (OGXM_BOARD == ADAFRUIT_FEATHER) || (OGXM_BOARD == RP2350_ZERO))
 
 #include <pico/multicore.h>
 
@@ -125,10 +125,10 @@ void standard::run() {
     }
 }
 
-// #else // OGXM_BOARD == PI_PICO || OGXM_BOARD == RP2040_ZERO || OGXM_BOARD == ADAFRUIT_FEATHER
+// #else // OGXM_BOARD == PI_PICO || OGXM_BOARD == RP2040_ZERO || OGXM_BOARD == ADAFRUIT_FEATHER || OGXM_BOARD == RP2350_ZERO
 
 // void standard::host_mounted(bool host_mounted) {}
 // void standard::initialize() {}
 // void standard::run() {}
 
-#endif // OGXM_BOARD == PI_PICO || OGXM_BOARD == RP2040_ZERO || OGXM_BOARD == ADAFRUIT_FEATHER
+#endif // OGXM_BOARD == PI_PICO || OGXM_BOARD == RP2040_ZERO || OGXM_BOARD == ADAFRUIT_FEATHER || OGXM_BOARD == RP2350_ZERO

--- a/Firmware/RP2040/src/OGXMini/OGXMini.cpp
+++ b/Firmware/RP2040/src/OGXMini/OGXMini.cpp
@@ -22,6 +22,7 @@ namespace OGXMini {
         esp32_br_i2c::initialize,   // ESP32_BLUERETRO_I2C
         four_ch_i2c::initialize,    // EXTERNAL_4CH_I2C
         four_ch_i2c::initialize,    // INTERNAL_4CH_I2C
+        standard::initialize,       // RP2350_ZERO
     };
 
     static constexpr RunFunc run_func[BOARDS_COUNT] = {
@@ -33,6 +34,7 @@ namespace OGXMini {
         esp32_br_i2c::run,      // ESP32_BLUERETRO_I2C
         four_ch_i2c::run,       // EXTERNAL_4CH_I2C
         four_ch_i2c::run,       // INTERNAL_4CH_I2C
+        standard::run,          // RP2350_ZERO
     };
 
     static constexpr HostMountedFunc host_mount_func[BOARDS_COUNT] = {
@@ -44,6 +46,7 @@ namespace OGXMini {
         nullptr,                    // ESP32_BLUERETRO_I2C
         four_ch_i2c::host_mounted,  // EXTERNAL_4CH_I2C
         four_ch_i2c::host_mounted,  // INTERNAL_4CH_I2C
+        standard::host_mounted,     // RP2350_ZERO
     };
 
     static constexpr HostMountedWTypeFunc host_mount_w_type_func[BOARDS_COUNT] = {
@@ -55,6 +58,7 @@ namespace OGXMini {
         nullptr,                            // ESP32_BLUERETRO_I2C
         four_ch_i2c::host_mounted_w_type,   // EXTERNAL_4CH_I2C
         four_ch_i2c::host_mounted_w_type,   // INTERNAL_4CH_I2C
+        nullptr,                            // RP2350_ZERO
     };
 
     static constexpr WirelessConnectedFunc wl_conn_func[BOARDS_COUNT] = {
@@ -66,6 +70,7 @@ namespace OGXMini {
         nullptr,                            // ESP32_BLUERETRO_I2C
         four_ch_i2c::wireless_connected,    // EXTERNAL_4CH_I2C
         four_ch_i2c::wireless_connected,    // INTERNAL_4CH_I2C
+        nullptr,                            // RP2350_ZERO
     };
 
     void initialize() {


### PR DESCRIPTION
The commit attached adds tested support for the RP2350_ZERO board by Waveshare

Uses the same pins as the RP2040_ZERO, as the boards are almost identical.

This has been tested with real hardware

(Admittedly did this as I bought the wrong board by accident)