### PR TITLE
Create automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,87 @@
+name: Build OGX-Mini
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        board:
+          - PI_PICO
+          - PI_PICO2
+          - PI_PICOW
+          - PI_PICO2W
+          - RP2040_ZERO
+          - ADAFRUIT_FEATHER
+          - ESP32_BLUEPAD32_I2C
+          - ESP32_BLUERETRO_I2C
+          #- EXTERNAL_4CH_I2C
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Dependencies
+        run: sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+
+      - name: Get Pico SDK
+        run: git clone --branch 2.1.0 --recurse-submodules https://github.com/raspberrypi/pico-sdk.git
+
+      - name: Create Build and Output Folders
+        run: mkdir -p build output
+
+      - name: Build OGX-Mini - ${{ matrix.board }}
+        run: |
+          cd build
+          rm -rf ./*
+          cmake -DPICO_SDK_PATH=${{ github.workspace }}/pico-sdk \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DOGXM_BOARD=${{ matrix.board }} \
+                -DMAX_GAMEPADS=1 \
+                ../Firmware/RP2040
+          cmake --build .
+
+          # Move the generated .uf2 file to output/ without knowing the exact version
+          FILE=$(find . -maxdepth 1 -name "OGX-Mini-*-${{ matrix.board }}.uf2" | head -n 1)
+          cp "$FILE" ../output/
+
+      - name: Upload UF2 Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: uf2-${{ matrix.board }}
+          path: output/*.uf2
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: output
+
+      - name: List Files
+        run: ls -lh output/**
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v2.2.2
+        #if: github.ref == 'refs/heads/main'
+        with:
+          tag_name: latest
+          draft: true
+          files: output/**/*.uf2
+
+      - name: Create Tagged Release
+        uses: softprops/action-gh-release@v2.2.2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: output/**/*.uf2

--- a/Firmware/RP2040/CMakeLists.txt
+++ b/Firmware/RP2040/CMakeLists.txt
@@ -25,7 +25,7 @@ set(BTSTACK_ROOT ${BLUEPAD32_ROOT}/external/btstack)
 set(PICO_BTSTACK_PATH ${BTSTACK_ROOT})
 set(LIBFIXMATH_PATH ${EXTERNAL_DIR}/libfixmath)
 
-get_pico_sdk(${EXTERNAL_DIR} ${PICOSDK_VERSION_TAG})
+#get_pico_sdk(${EXTERNAL_DIR} ${PICOSDK_VERSION_TAG})
 init_git_submodules(${EXTERNAL_DIR}
     ${BLUEPAD32_ROOT}
     ${PICO_TINYUSB_PATH}
@@ -299,14 +299,6 @@ if(NOT EN_BLUETOOTH)
 endif()
 
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-
-message("PICO_SDK_VERSION_STRING: ${PICO_SDK_VERSION_STRING}")
-if(PICO_SDK_VERSION_STRING VERSION_LESS "${PICOSDK_VERSION_TAG}")
-    message(FATAL_ERROR 
-        "Raspberry Pi Pico SDK version ${PICOSDK_VERSION_TAG} (or later) required. 
-        Your version is ${PICO_SDK_VERSION_STRING}"
-    )
-endif()
 
 project(${FW_NAME} C CXX ASM)
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ The options are:
 - ```PI_PICO2``` 
 - ```PI_PICOW``` 
 - ```PI_PICO2W``` 
-- ```RP_ZERO``` 
-- ```ADA_FEATHER``` 
-- ```PICO_ESP32``` 
-- ```EXTERNAL_4CH```
+- ```RP2040_ZERO``` 
+- ```ADAFRUIT_FEATHER``` 
+- ```ESP32_BLUEPAD32_I2C```
+- ```ESP32_BLUERETRO_I2C``` 
+- ```EXTERNAL_4CH_I2C```
 
 You can also set ```MAX_GAMEPADS``` which, if greater than one, will only support DInput (PS3) and Switch.
 


### PR DESCRIPTION
Had users in xbox-scene request for uf2 builds, and rather than do a manual build I decided to create a build action, which seems to be working well...

<img width="1894" height="1148" alt="image" src="https://github.com/user-attachments/assets/d981e53a-4307-4334-9cc9-e4718c844813" />

I thought it would be a good idea to give this as a PR

Some notes:

* I had to disable EXTERNAL_4CH_I2C board as has a i2c error
* I fixed main readme to reflect correct board options
* I had to remove sdk version check as seemed to be empty string
* In the build.yml I disabled 'if: github.ref == 'refs/heads/main'' so would build on all branches, but you can change to your requirement.

Hope this helps...

EqUiNoX