### PR TITLE
Fix wired DS4 PS/touchpad button masking in PS4 USB host parser

### DIFF
--- a/Firmware/RP2040/src/USBHost/HostDriver/PS4/PS4.cpp
+++ b/Firmware/RP2040/src/USBHost/HostDriver/PS4/PS4.cpp
@@ -18,7 +18,7 @@ void PS4Host::initialize(Gamepad& gamepad, uint8_t address, uint8_t instance, co
 void PS4Host::process_report(Gamepad& gamepad, uint8_t address, uint8_t instance, const uint8_t* report, uint16_t len)
 {
     std::memcpy(&in_report_, report, std::min(static_cast<size_t>(len), sizeof(PS4::InReport)));
-    in_report_.buttons[2] &= PS4::COUNTER_MASK;
+    in_report_.buttons[2] &= static_cast<uint8_t>(~PS4::COUNTER_MASK);
     if (std::memcmp(reinterpret_cast<const PS4::InReport*>(report), &prev_in_report_, sizeof(PS4::InReport)) == 0)
     {
         return;


### PR DESCRIPTION
Fixes #209. 

In Firmware/RP2040/src/USBHost/HostDriver/PS4/PS4.cpp, buttons[2] is masked with PS4::COUNTER_MASK (0xFC) before the PS and touchpad bits are checked. On wired DS4 USB reports, the PS and touchpad bits are the low two bits of buttons[2], so the current mask clears them before MAP_BUTTON_SYS / MAP_BUTTON_MISC are tested.

This line changes the mask to preserve the low two bits while clearing the counter bits:

in_report_.buttons[2] &= static_cast<uint8_t>(~PS4::COUNTER_MASK);

Tested:
- Pi Pico
- Waveshare RP2350-USB-A
- Wired DS4
- XInput mode
- before fix: PS button did not register as Guide
- after fix: PS button opens the Xbox Guide successfully